### PR TITLE
Add shared-context post and ads.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,41 @@ Source code for **https://gnamal.com**.
 A minimal personal site + blog for **Gökhan Namal**.
 
 ## What’s inside
+
 - Home, About, Beliefs
 - Reading (Goodreads shelves via RSS)
 - Bookmarks
 - Apps (from Apple iTunes Search API)
 
 ## Tech stack
+
 - **Astro** (based on **AstroPaper**)
 - **Tailwind CSS**
 - **GitHub Pages** (deploy via GitHub Actions)
 
 ## Local development
+
 ```bash
 pnpm install
 pnpm dev
 ```
 
 ## Build
+
 ```bash
 pnpm build
 ```
 
 ## Content
+
 - Blog posts live in: `src/data/blog/`
 - Pages live in: `src/pages/`
 
 ## Licenses
+
 - **Code**: MIT (see `LICENSE`)
 - **Site content (posts/pages)**: CC BY 4.0 (see `CONTENT_LICENSE.md`)
 
 ## Credits
+
 - Theme foundation: https://github.com/satnaing/astro-paper

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+withgrowl.com, b0d62666670f460a8c6b5f2becea24ff, DIRECT

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,7 +20,9 @@ const { noMarginTop = false, class: className, ...attrs } = Astro.props;
       "flex flex-col items-center gap-3 sm:flex-row sm:justify-between",
     ]}
   >
-    <div class="flex flex-col items-center text-center sm:items-start sm:text-left">
+    <div
+      class="flex flex-col items-center text-center sm:items-start sm:text-left"
+    >
       <span>
         <a
           class="underline underline-offset-4 hover:text-accent"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,7 +30,9 @@ const isActive = (path: string) => {
   Skip to content
 </a>
 
-<header class="app-layout flex flex-col items-center justify-between sm:flex-row">
+<header
+  class="app-layout flex flex-col items-center justify-between sm:flex-row"
+>
   <div
     id="top-nav-wrap"
     class:list={[
@@ -72,7 +74,10 @@ const isActive = (path: string) => {
         ]}
       >
         <li class="col-span-2">
-          <a href="/reading" class:list={{ "active-nav": isActive("/reading") }}>
+          <a
+            href="/reading"
+            class:list={{ "active-nav": isActive("/reading") }}
+          >
             Reading
           </a>
         </li>

--- a/src/data/blog/shared-context-company-ai-library.md
+++ b/src/data/blog/shared-context-company-ai-library.md
@@ -1,0 +1,165 @@
+---
+author: Gökhan Namal
+pubDatetime: 2026-04-02T09:00:00-08:00
+title: How to build a shared AI context for your engineering team
+featured: false
+draft: false
+tags:
+  - engineering
+  - ai
+  - tooling
+description: "Stop rebuilding context from scratch every session. Build a shared AI library your team installs once, improves together, and reuses across every repo."
+---
+
+An iOS engineer opens a new repo. Before writing a single line of code, they open Claude and start typing.
+
+"We use SwiftUI. We follow MVVM with the Observation framework. Our PR process requires a changelog entry, a screenshot for UI changes, and a reviewer from the team. Our CI runs on Buildkite and takes about 12 minutes..."
+
+They've typed this before. Yesterday, in a different repo. Somewhere across the org, a backend engineer is doing the same thing with a different stack. Each one rebuilding context from scratch, every session, for every repo.
+
+---
+
+## The problem: every session starts from zero
+
+Consider the same task done twice. Two engineers at the same company both ask Claude to review a pull request. The first gets generic feedback: the code looks correct, consider adding tests, the naming is reasonable. The second gets something different: Claude checks their SwiftUI conventions, flags a missing `accessibilityLabel` their design system requires, notes the PR is missing a changelog entry their release process mandates, and catches a memory management pattern their team learned the hard way six months ago.
+
+Same model. Same company. Same task. The only difference is that one engineer has shared context loaded.
+
+The second engineer has a `/pr-review` skill installed: a markdown file that encodes exactly what a good PR looks like at their company. Not generic code review knowledge. Their code review knowledge.
+
+The fix is not more prompting discipline. It is shared infrastructure: context your team builds once, installs anywhere, and improves over time. Engineers publish skills publicly too. [Dimillian's skill library](https://github.com/dimillian/skills) is one example: high-quality SwiftUI and iOS skills any team can install and adapt.
+
+---
+
+## What you can actually share
+
+**Skills** are reusable procedures invoked as slash commands: `/pr-review`, `/deploy-staging`, `/incident-response`. A skill loads and the AI has what it needs to act on your conventions instead of generic ones. Any repeated task is a candidate: ADRs, post-mortems, security checklists, feature scaffolding. Skills can embed existing runbooks, so your incident runbook becomes the incident skill rather than something engineers have to find separately.
+
+**Hooks** are automated behaviors triggered by events. Run a linter after every file edit. Validate commit message format before every commit. Enforce patterns without asking anyone to remember.
+
+---
+
+## Three ways to share context
+
+The simplest option is a shared `CLAUDE.md` or `AGENTS.md` file: one document with your conventions, committed to a shared repo. It works across any AI coding tool and requires nothing beyond a text file.
+
+It breaks down fast. [OpenAI's engineering team tried this](https://openai.com/index/harness-engineering/) and documented the failure modes: context is a scarce resource, and a giant instruction file crowds out the task, the code, and the relevant docs. Too much guidance becomes non-guidance. When everything is "important," nothing is. The file rots instantly, humans stop maintaining it, and agents can't tell what's still true.
+
+The second option is a script-based approach like [skills.sh](https://skills.sh): a tool that installs skills into your local Claude setup without a Git-backed marketplace. It works well for individuals or small teams who want to share a set of skills without committing to a repository structure. The tradeoff is that updates are manual and there is no per-domain organization.
+
+The third option is a marketplace with plugins: a Git repository that organizes skills by domain, installs globally, and updates automatically. The iOS team gets iOS skills, the backend team gets backend skills, everyone gets the shared ones. The rest of this article covers how to set this up.
+
+---
+
+## How to build a company marketplace
+
+One Git repository becomes the company's shared AI library.
+
+```
+acme-corp/claude-marketplace
+├── .claude-plugin/
+│   └── marketplace.json
+└── plugins/
+    ├── shared/                # Company-wide skills
+    │   ├── .claude-plugin/plugin.json
+    │   └── skills/
+    │       ├── pr-review/SKILL.md
+    │       └── incident/SKILL.md
+    ├── ios/
+    ├── android/
+    ├── backend/
+    └── design-system/
+```
+
+The `marketplace.json` at the root is the catalog:
+
+```json
+{
+  "name": "acme-tools",
+  "owner": { "name": "Acme DevTools Team", "email": "devtools@acme.com" },
+  "metadata": { "pluginRoot": "./plugins" },
+  "plugins": [
+    { "name": "shared", "source": "./shared", "description": "Company-wide skills" },
+    { "name": "ios", "source": "./ios", "description": "iOS engineering skills" },
+    { "name": "android", "source": "./android", "description": "Android engineering skills" },
+    { "name": "backend", "source": "./backend", "description": "Backend engineering skills" }
+  ]
+}
+```
+
+Each plugin is independently installable. An iOS engineer installs `shared` and `ios`. A new joiner installs both relevant plugins and immediately has an AI that knows how their org does engineering.
+
+### Auto-setup for new joiners
+
+Add this to `.claude/settings.json` in any shared org repo:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "acme-tools": {
+      "source": { "source": "github", "repo": "acme-corp/claude-marketplace" }
+    }
+  },
+  "enabledPlugins": {
+    "shared@acme-tools": true
+  }
+}
+```
+
+New joiners clone the repo, get prompted to install the marketplace, pick their domain plugins, and have skills available across every repo they work in.
+
+### Pushing plugins to everyone (enterprise)
+
+For enterprise teams, there is a way to skip the self-install step entirely. In the Claude.ai admin console, navigate to **Admin Settings > Claude Code > Managed settings**. Adding plugins here pushes them to every user automatically. When engineers authenticate with org credentials, the plugins are already there and cannot be overridden or uninstalled by individual users.
+
+```json
+{
+  "enabledPlugins": {
+    "shared@acme-tools": true,
+    "ios@acme-tools": true
+  }
+}
+```
+
+Use this for anything the org considers non-negotiable: security checklists, incident response, compliance requirements.
+
+### Keeping skills up to date automatically
+
+A hook handles updates: pull the latest from the marketplace repo before each session, so every engineer picks up changes without a manual step.
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git -C ~/acme-claude-marketplace pull --quiet 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Add this to `~/.claude/settings.json`. When someone improves the `/incident-response` skill or tightens the iOS checklist, every engineer gets it on their next prompt. The `|| true` keeps it silent if the network is unavailable.
+
+---
+
+## Maintaining the library
+
+A simple rule: if you explain something to Claude twice, it belongs in a skill.
+
+An engineer debugging a flaky test explains the team's specific retry helper and why the standard approach breaks on their CI. Two weeks later, a different engineer hits the same issue and types the same explanation from scratch. That is when someone opens a PR to the marketplace repo. Now no one on the team types it again.
+
+The capture moment happens mid-session: the engineer corrects the AI ("no, do it like this instead") or confirms something worked ("yes, exactly that"). The habit is to notice those moments and open a PR before the session ends. Treat it like a doc that got out of date: someone notices, someone fixes it, everyone benefits.
+
+---
+
+## Where to start
+
+Pick the task your team explains to AI tools most often. PR review is a common first choice: everyone does it and the conventions are specific to your team. Write the skill, get two or three engineers to use it for a week, and see what is missing.
+
+A working example marketplace is available at [github.com/gokhanamal/claude-marketplace-template](https://github.com/gokhanamal/claude-marketplace-template) with the structure above, a shared plugin, and a starter iOS plugin. Fork it, rename the plugins for your org, and add your first skill. The next time an engineer opens a new repo, they will not have to type any of it again.

--- a/src/data/blog/shared-context-company-ai-library.md
+++ b/src/data/blog/shared-context-company-ai-library.md
@@ -79,10 +79,26 @@ The `marketplace.json` at the root is the catalog:
   "owner": { "name": "Acme DevTools Team", "email": "devtools@acme.com" },
   "metadata": { "pluginRoot": "./plugins" },
   "plugins": [
-    { "name": "shared", "source": "./shared", "description": "Company-wide skills" },
-    { "name": "ios", "source": "./ios", "description": "iOS engineering skills" },
-    { "name": "android", "source": "./android", "description": "Android engineering skills" },
-    { "name": "backend", "source": "./backend", "description": "Backend engineering skills" }
+    {
+      "name": "shared",
+      "source": "./shared",
+      "description": "Company-wide skills"
+    },
+    {
+      "name": "ios",
+      "source": "./ios",
+      "description": "iOS engineering skills"
+    },
+    {
+      "name": "android",
+      "source": "./android",
+      "description": "Android engineering skills"
+    },
+    {
+      "name": "backend",
+      "source": "./backend",
+      "description": "Backend engineering skills"
+    }
   ]
 }
 ```

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -8,6 +8,7 @@ Hi, I’m **Gökhan Namal**.
 This is my personal site — short notes about building, investing, and life.
 
 ## Links
+
 - Website: <https://gnamal.com>
 - GitHub: <https://github.com/gokhanamal>
 - X/Twitter: <https://x.com/gokhanamal>
@@ -16,8 +17,10 @@ This is my personal site — short notes about building, investing, and life.
 If you want to reach me, the easiest way is via LinkedIn or X.
 
 ## Writing
+
 - Beliefs: <https://gnamal.com/beliefs>
 
 ## Apps
+
 - App Store developer page: <https://apps.apple.com/us/developer/gokhan-namal/id1476997783>
 - This site: <https://gnamal.com/apps>

--- a/src/pages/apps.astro
+++ b/src/pages/apps.astro
@@ -6,8 +6,8 @@ import Main from "@/layouts/Main.astro";
 import { SITE } from "@/config";
 
 type App = {
-  trackId: number;
-  trackName: string;
+  trackId?: number;
+  trackName?: string;
   description?: string;
   artworkUrl512?: string;
   formattedPrice?: string;
@@ -15,6 +15,11 @@ type App = {
   userRatingCount?: number;
   primaryGenreName?: string;
   trackViewUrl?: string;
+};
+
+type ItunesResult = App & {
+  wrapperType?: string;
+  artistLinkUrl?: string;
 };
 
 const DEVELOPER_ID = 1476997783;
@@ -29,7 +34,7 @@ let developerUrl = "https://apps.apple.com/us/developer/gokhan-namal/id147699778
 
 if (res.ok) {
   const data = await res.json();
-  const results = (data?.results ?? []) as any[];
+  const results = (data?.results ?? []) as ItunesResult[];
   const artist = results.find((r) => r.wrapperType === "artist");
   if (artist?.artistLinkUrl) developerUrl = artist.artistLinkUrl;
 

--- a/src/pages/apps.astro
+++ b/src/pages/apps.astro
@@ -26,21 +26,22 @@ const DEVELOPER_ID = 1476997783;
 
 const res = await fetch(
   `https://itunes.apple.com/lookup?id=${DEVELOPER_ID}&entity=software`,
-  { headers: { "Accept": "application/json" } }
+  { headers: { Accept: "application/json" } }
 );
 
 let apps: App[] = [];
-let developerUrl = "https://apps.apple.com/us/developer/gokhan-namal/id1476997783";
+let developerUrl =
+  "https://apps.apple.com/us/developer/gokhan-namal/id1476997783";
 
 if (res.ok) {
   const data = await res.json();
   const results = (data?.results ?? []) as ItunesResult[];
-  const artist = results.find((r) => r.wrapperType === "artist");
+  const artist = results.find(r => r.wrapperType === "artist");
   if (artist?.artistLinkUrl) developerUrl = artist.artistLinkUrl;
 
   apps = results
-    .filter((r) => r.wrapperType === "software")
-    .map((r) => ({
+    .filter(r => r.wrapperType === "software")
+    .map(r => ({
       trackId: r.trackId,
       trackName: r.trackName,
       description: r.description,
@@ -59,47 +60,69 @@ if (res.ok) {
   <Header />
   <Main pageTitle="Apps" pageDesc="A list of iOS apps I’ve published.">
     <p class="mt-2">
-      <a class="underline hover:text-accent" href={developerUrl} target="_blank" rel="noreferrer">
+      <a
+        class="underline hover:text-accent"
+        href={developerUrl}
+        target="_blank"
+        rel="noreferrer"
+      >
         View on the App Store
       </a>
     </p>
 
     <ul class="mt-6 grid gap-4 sm:grid-cols-2">
-      {apps.map((a) => (
-        <li class="rounded-xl border border-border p-4">
-          <a class="flex gap-4 hover:text-accent" href={a.trackViewUrl} target="_blank" rel="noreferrer">
-            {a.artworkUrl512 && (
-              <img
-                src={a.artworkUrl512}
-                alt=""
-                loading="lazy"
-                class="h-16 w-16 rounded-2xl border border-border object-cover"
-              />
-            )}
-            <div class="min-w-0">
-              <div class="font-semibold leading-snug">{a.trackName}</div>
-              <div class="mt-1 text-sm opacity-80 line-clamp-2">
-                {a.description ?? ""}
+      {
+        apps.map(a => (
+          <li class="rounded-xl border border-border p-4">
+            <a
+              class="flex gap-4 hover:text-accent"
+              href={a.trackViewUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {a.artworkUrl512 && (
+                <img
+                  src={a.artworkUrl512}
+                  alt=""
+                  loading="lazy"
+                  class="h-16 w-16 rounded-2xl border border-border object-cover"
+                />
+              )}
+              <div class="min-w-0">
+                <div class="leading-snug font-semibold">{a.trackName}</div>
+                <div class="mt-1 line-clamp-2 text-sm opacity-80">
+                  {a.description ?? ""}
+                </div>
+                <div class="mt-2 text-xs opacity-70">
+                  {a.primaryGenreName ? `${a.primaryGenreName}` : ""}
+                  {a.formattedPrice ? ` · ${a.formattedPrice}` : ""}
+                  {typeof a.averageUserRating === "number"
+                    ? ` · ★ ${a.averageUserRating.toFixed(1)}`
+                    : ""}
+                </div>
               </div>
-              <div class="mt-2 text-xs opacity-70">
-                {a.primaryGenreName ? `${a.primaryGenreName}` : ""}
-                {a.formattedPrice ? ` · ${a.formattedPrice}` : ""}
-                {typeof a.averageUserRating === "number" ? ` · ★ ${a.averageUserRating.toFixed(1)}` : ""}
-              </div>
-            </div>
-          </a>
-        </li>
-      ))}
+            </a>
+          </li>
+        ))
+      }
     </ul>
 
-    {apps.length === 0 && (
-      <p class="mt-6 opacity-80">
-        Couldn’t load the App Store list right now. You can still view it here:
-        <a class="underline hover:text-accent" href={developerUrl} target="_blank" rel="noreferrer">
-          {developerUrl}
-        </a>
-      </p>
-    )}
+    {
+      apps.length === 0 && (
+        <p class="mt-6 opacity-80">
+          Couldn’t load the App Store list right now. You can still view it
+          here:
+          <a
+            class="underline hover:text-accent"
+            href={developerUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {developerUrl}
+          </a>
+        </p>
+      )
+    }
   </Main>
   <Footer />
 </Layout>

--- a/src/pages/beliefs.md
+++ b/src/pages/beliefs.md
@@ -6,20 +6,24 @@ title: "Beliefs"
 A running list of things I believe.
 
 ## Product & craft
+
 - Shipping small things consistently beats planning big things perfectly.
 - The best products feel obvious in hindsight.
 - Great UX is often just removing friction.
 
 ## Engineering
+
 - Developer experience is a product.
 - Tooling pays compounding interest.
 - Defaults matter more than docs.
 
 ## AI
+
 - LLMs are leverage — but only if you build reliable workflows around them.
 - The best use cases start narrow and become general over time.
 
 ## Life
+
 - Consistency beats intensity.
 - Protect your attention.
 

--- a/src/pages/bookmarks.astro
+++ b/src/pages/bookmarks.astro
@@ -18,22 +18,39 @@ const items = bookmarks as Bookmark[];
 
 <Layout title={`Bookmarks | ${SITE.title}`}>
   <Header />
-  <Main pageTitle="Bookmarks" pageDesc="A small list of links I keep coming back to.">
+  <Main
+    pageTitle="Bookmarks"
+    pageDesc="A small list of links I keep coming back to."
+  >
     <ul class="mt-6 grid gap-4 sm:grid-cols-2">
-      {items.map((b) => (
-        <li class="rounded-xl border border-border p-4">
-          <a class="flex gap-4 hover:text-accent" href={b.url} target="_blank" rel="noreferrer">
-            {b.image && (
-              <img src={b.image} alt="" loading="lazy" class="h-20 w-20 rounded-lg border border-border object-cover" />
-            )}
-            <div>
-              <div class="font-semibold">{b.title}</div>
-              {b.description && <div class="mt-1 text-sm opacity-80">{b.description}</div>}
-              <div class="mt-2 text-xs opacity-60">{b.url}</div>
-            </div>
-          </a>
-        </li>
-      ))}
+      {
+        items.map(b => (
+          <li class="rounded-xl border border-border p-4">
+            <a
+              class="flex gap-4 hover:text-accent"
+              href={b.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {b.image && (
+                <img
+                  src={b.image}
+                  alt=""
+                  loading="lazy"
+                  class="h-20 w-20 rounded-lg border border-border object-cover"
+                />
+              )}
+              <div>
+                <div class="font-semibold">{b.title}</div>
+                {b.description && (
+                  <div class="mt-1 text-sm opacity-80">{b.description}</div>
+                )}
+                <div class="mt-2 text-xs opacity-60">{b.url}</div>
+              </div>
+            </a>
+          </li>
+        ))
+      }
     </ul>
 
     <p class="mt-8 text-sm opacity-70">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,15 +30,24 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
           </h1>
 
           <p class="mt-3">
-            Product-minded iOS engineer focused on developer experience, tooling, and LLMs.
-            I build and ship iOS apps.
+            Product-minded iOS engineer focused on developer experience,
+            tooling, and LLMs. I build and ship iOS apps.
           </p>
           <p class="mt-2">
-            Start with the <LinkButton class="underline decoration-dashed underline-offset-4 hover:text-accent" href="/about">about page</LinkButton>.
+            Start with the <LinkButton
+              class="underline decoration-dashed underline-offset-4 hover:text-accent"
+              href="/about">about page</LinkButton
+            >.
             <br />
-            Or see <LinkButton class="underline decoration-dashed underline-offset-4 hover:text-accent" href="/beliefs">what I believe</LinkButton>.
+            Or see <LinkButton
+              class="underline decoration-dashed underline-offset-4 hover:text-accent"
+              href="/beliefs">what I believe</LinkButton
+            >.
             <br />
-            You can also browse <LinkButton class="underline decoration-dashed underline-offset-4 hover:text-accent" href="/apps">my iOS apps</LinkButton>.
+            You can also browse <LinkButton
+              class="underline decoration-dashed underline-offset-4 hover:text-accent"
+              href="/apps">my iOS apps</LinkButton
+            >.
           </p>
 
           <div class="mt-3 flex items-center gap-3">

--- a/src/pages/reading.astro
+++ b/src/pages/reading.astro
@@ -39,15 +39,21 @@ function decodeHtml(s: string) {
 
 function parseItems(xml: string): Book[] {
   const items = xml.match(/<item>[\s\S]*?<\/item>/gi) ?? [];
-  return items.map((it) => {
+  return items.map(it => {
     const title = decodeHtml(unCDATA(pick("title", it)));
     const author = decodeHtml(unCDATA(pick("author_name", it)));
-    const image = decodeHtml(unCDATA(pick("book_medium_image_url", it))) || decodeHtml(unCDATA(pick("book_image_url", it)));
+    const image =
+      decodeHtml(unCDATA(pick("book_medium_image_url", it))) ||
+      decodeHtml(unCDATA(pick("book_image_url", it)));
 
     // Prefer direct book URL if present in description.
     const desc = unCDATA(pick("description", it));
-    const hrefMatch = desc.match(/href="(https:\/\/www\.goodreads\.com\/book\/show\/[^"]+)"/i);
-    const url = hrefMatch ? decodeHtml(hrefMatch[1]) : decodeHtml(unCDATA(pick("link", it)));
+    const hrefMatch = desc.match(
+      /href="(https:\/\/www\.goodreads\.com\/book\/show\/[^"]+)"/i
+    );
+    const url = hrefMatch
+      ? decodeHtml(hrefMatch[1])
+      : decodeHtml(unCDATA(pick("link", it)));
 
     const pubDate = decodeHtml(unCDATA(pick("pubDate", it)));
 
@@ -80,62 +86,109 @@ const [currentlyReading, read, toRead] = await Promise.all([
       <section>
         <h2 class="text-2xl font-semibold tracking-wide">Currently reading</h2>
         <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-          {currentlyReading.slice(0, 6).map((b) => (
-            <li class="rounded-xl border border-border p-4">
-              <a class="flex gap-4 hover:text-accent" href={b.url} target="_blank" rel="noreferrer">
-                {b.image && (
-                  <img src={b.image} alt="" loading="lazy" class="h-24 w-16 rounded-md border border-border object-cover" />
-                )}
-                <div>
-                  <div class="font-semibold">{b.title}</div>
-                  {b.author && <div class="text-sm opacity-80">{b.author}</div>}
-                </div>
-              </a>
-            </li>
-          ))}
+          {
+            currentlyReading.slice(0, 6).map(b => (
+              <li class="rounded-xl border border-border p-4">
+                <a
+                  class="flex gap-4 hover:text-accent"
+                  href={b.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {b.image && (
+                    <img
+                      src={b.image}
+                      alt=""
+                      loading="lazy"
+                      class="h-24 w-16 rounded-md border border-border object-cover"
+                    />
+                  )}
+                  <div>
+                    <div class="font-semibold">{b.title}</div>
+                    {b.author && (
+                      <div class="text-sm opacity-80">{b.author}</div>
+                    )}
+                  </div>
+                </a>
+              </li>
+            ))
+          }
         </ul>
       </section>
 
       <section>
         <h2 class="text-2xl font-semibold tracking-wide">Read (recent)</h2>
         <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-          {read.slice(0, 10).map((b) => (
-            <li class="rounded-xl border border-border p-4">
-              <a class="flex gap-4 hover:text-accent" href={b.url} target="_blank" rel="noreferrer">
-                {b.image && (
-                  <img src={b.image} alt="" loading="lazy" class="h-24 w-16 rounded-md border border-border object-cover" />
-                )}
-                <div>
-                  <div class="font-semibold">{b.title}</div>
-                  {b.author && <div class="text-sm opacity-80">{b.author}</div>}
-                </div>
-              </a>
-            </li>
-          ))}
+          {
+            read.slice(0, 10).map(b => (
+              <li class="rounded-xl border border-border p-4">
+                <a
+                  class="flex gap-4 hover:text-accent"
+                  href={b.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {b.image && (
+                    <img
+                      src={b.image}
+                      alt=""
+                      loading="lazy"
+                      class="h-24 w-16 rounded-md border border-border object-cover"
+                    />
+                  )}
+                  <div>
+                    <div class="font-semibold">{b.title}</div>
+                    {b.author && (
+                      <div class="text-sm opacity-80">{b.author}</div>
+                    )}
+                  </div>
+                </a>
+              </li>
+            ))
+          }
         </ul>
       </section>
 
       <section>
         <h2 class="text-2xl font-semibold tracking-wide">Want to read</h2>
         <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-          {toRead.slice(0, 8).map((b) => (
-            <li class="rounded-xl border border-border p-4">
-              <a class="flex gap-4 hover:text-accent" href={b.url} target="_blank" rel="noreferrer">
-                {b.image && (
-                  <img src={b.image} alt="" loading="lazy" class="h-24 w-16 rounded-md border border-border object-cover" />
-                )}
-                <div>
-                  <div class="font-semibold">{b.title}</div>
-                  {b.author && <div class="text-sm opacity-80">{b.author}</div>}
-                </div>
-              </a>
-            </li>
-          ))}
+          {
+            toRead.slice(0, 8).map(b => (
+              <li class="rounded-xl border border-border p-4">
+                <a
+                  class="flex gap-4 hover:text-accent"
+                  href={b.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {b.image && (
+                    <img
+                      src={b.image}
+                      alt=""
+                      loading="lazy"
+                      class="h-24 w-16 rounded-md border border-border object-cover"
+                    />
+                  )}
+                  <div>
+                    <div class="font-semibold">{b.title}</div>
+                    {b.author && (
+                      <div class="text-sm opacity-80">{b.author}</div>
+                    )}
+                  </div>
+                </a>
+              </li>
+            ))
+          }
         </ul>
       </section>
 
       <p class="text-sm opacity-80">
-        Source: <a class="underline hover:text-accent" href="https://www.goodreads.com/user/show/58980151-g-khan" target="_blank" rel="noreferrer">Goodreads profile</a>
+        Source: <a
+          class="underline hover:text-accent"
+          href="https://www.goodreads.com/user/show/58980151-g-khan"
+          target="_blank"
+          rel="noreferrer">Goodreads profile</a
+        >
       </p>
     </div>
   </Main>


### PR DESCRIPTION
## Summary
- Adds a new blog post, *How to build a shared AI context for your engineering team*, at `src/data/blog/shared-context-company-ai-library.md`. Migrated from a Jekyll-style draft in `_posts/` and rewritten to validate against AstroPaper's content collection schema (`pubDatetime`, `description`, `tags`).
- Adds `public/ads.txt` with the Growl authorized-seller record. Astro serves `public/` verbatim at the site root, so it will be reachable at `https://gnamal.com/ads.txt` after deploy.

## Test plan
- [ ] `pnpm astro check` passes (frontmatter validates against the Zod schema in `src/content.config.ts`)
- [ ] `pnpm dev` renders the post at `/posts/shared-context-company-ai-library/`
- [ ] `/ads.txt` returns `withgrowl.com, b0d62666670f460a8c6b5f2becea24ff, DIRECT` as `text/plain`
- [ ] Post appears in the blog index and RSS feed with the expected description and tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)